### PR TITLE
Add Claude Code Skills 中文精选集

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ npx skills list
 | **LobeHub Skills** | 232+ skills 的可视化浏览 | [lobehub.com/skills](https://lobehub.com/skills) |
 | **hotkeys.design** | 设计师向的 Skill 导航站 | [hotkeys.design](https://hotkeys.design) |
 | **awesomeskills.dev** | 跨平台 Agent Skill 目录 | [awesomeskills.dev](https://awesomeskills.dev) |
+| **Claude Code Skills 中文精选集** | 中文 Claude Code Skills / Agents / Plugins 精选，适合中文用户快速筛选 | [claude-skills.bt199.com](https://claude-skills.bt199.com/) |
 
 ---
 


### PR DESCRIPTION
## Summary
- Add a Chinese Claude Code Skills directory to the 合集 / 导航站 section.
- The resource curates Claude Code Skills, Agents, and Plugins for Chinese-speaking developers.

## Why it fits
This repo already includes navigation resources such as skills.sh, LobeHub Skills, and awesomeskills.dev. This addition helps Chinese users discover and compare Claude Code resources in their own language.

## Checklist
- [x] Kept the existing table format
- [x] Added one focused, relevant resource
- [x] Verified the link is reachable
