### PR TITLE
添加 html-anything 到 设计/UI 分类

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ npx skills list
 | [TypeUI Design Skills](https://www.typeui.sh/design-skills) | TypeUI | 可选 | 手工 skill 文件，复现特定视觉风格 | `npx typeui.sh pull [name]` |
 | [Design.md Generator](https://github.com/google-labs-code/stitch-skills) | Google Labs | 好用 | 分析项目 → 自动生成 DESIGN.md 设计规范 | `npx skills add google-labs-code/stitch-skills@design-md` |
 | [Brainstorming](https://github.com/obra/superpowers) | obra | 强推 | 验证设计方案后才允许写代码，防止 AI 乱写 | `npx skills add obra/superpowers@brainstorming` |
+| [html-anything](https://github.com/clockless-org/html-anything) | Clockless | 强推 | 文件 / 导出 / 链接 → 单文件 HTML 网页，16 个设计系统自动选（lesson lab / map atlas / timeline story / relationship / network map / dashboard / document / …） | `npx skills add clockless-org/html-anything` |
 
 ---
 


### PR DESCRIPTION
添加 [`clockless-org/html-anything`](https://github.com/clockless-org/html-anything) 到 **设计 / UI** 分类。

> **Install once. 你的 agent 在内容本身是"页面"而非"对话消息"的时候，直接把答案做成漂亮的网页。**

`html-anything` 把 agent 的复杂回答——以及任意 file / folder / URL / service export（Amazon orders / Kindle highlights / Spotify history / WeChat / iMessage / Google Photos Takeout / LinkedIn / CSV / PDF / DOCX / 日志 / GPX...）——变成单文件 HTML 网页。Skill 自动选 16 个 design system 中最合适的一个（`teaching` / `relationship` / `timeline-story` / `map-atlas` / `network-map` / `document` / `developer` / `living-essay` / `editorial-carousel` / `paper-trail` 等），生成 HTML，在浏览器里验证，交付。短对话保持短。

**安装**：`npx skills add clockless-org/html-anything`

**Live gallery（22 个 demo）**：https://clockless-org.github.io/html-anything/examples/

样例输出：
- Kindle 笔记 → [living-essay](https://clockless-org.github.io/html-anything/examples/kindle-highlights/output.html)
- 太阳系教学站 → [teaching](https://clockless-org.github.io/html-anything/examples/solar-system-studio/output.html)
- WeChat 情侣聊天分析 → [relationship](https://clockless-org.github.io/html-anything/examples/wechat-couple/output.html)
- Google Maps 收藏地图 → [map-atlas](https://clockless-org.github.io/html-anything/examples/google-maps-stars/output.html)
- LinkedIn 人脉图 → [network-map](https://clockless-org.github.io/html-anything/examples/linkedin-connections/output.html)

Apache 2.0 · 跨工具（Claude Code / Codex / Cursor / Cline / Windsurf） · 已在 [skills.sh](https://skills.sh/clockless-org/html-anything)