### PR TITLE
Add oh-story-claudecode + 新增「写作/创作」分类

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ npx skills list
 - [前端开发](#前端开发)
 - [动效 / 视频](#动效--视频)
 - [营销 / SEO](#营销--seo)
+- [写作 / 创作](#写作--创作)
 - [代码质量](#代码质量)
 - [工作流 / 方法论](#工作流--方法论)
 - [无障碍](#无障碍)
@@ -129,6 +130,16 @@ npx skills list
 | [Product Marketing Context](https://github.com/coreyhaines31/marketingskills) | Corey Haines | 好用 | 产品定位 / 人群 / 竞品 / 品牌声音 | `npx skills add coreyhaines31/marketingskills@product-marketing-context` |
 | [Pricing Strategy](https://github.com/coreyhaines31/marketingskills) | Corey Haines | 好用 | SaaS 定价设计与竞品对比框架 | `npx skills add coreyhaines31/marketingskills@pricing-strategy` |
 | [Twitter Automation](https://github.com/inferen-sh/skills) | inference.sh | 可选 | 推文 / 点赞 / 转推 / DM，9 个命令 | `npx skills add inferen-sh/skills@twitter-automation` |
+
+---
+
+## 写作 / 创作
+
+用 AI 辅助创意写作。
+
+| Skill | 作者 | 推荐 | 一句话 | 安装 |
+|-------|------|------|--------|------|
+| [oh-story-claudecode](https://github.com/worldwonderer/oh-story-claudecode) | worldwonderer | 强推 | 13 skills + 6 agents 覆盖长篇/短篇网文全流程（扫榜/拆文/写作/去AI味/封面/导入） | `npx skills add worldwonderer/oh-story-claudecode` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ npx skills list
 - [前端开发](#前端开发)
 - [动效 / 视频](#动效--视频)
 - [营销 / SEO](#营销--seo)
-- [写作 / 创作](#写作--创作)
 - [代码质量](#代码质量)
 - [工作流 / 方法论](#工作流--方法论)
 - [无障碍](#无障碍)
@@ -133,16 +132,6 @@ npx skills list
 
 ---
 
-## 写作 / 创作
-
-用 AI 辅助创意写作。
-
-| Skill | 作者 | 推荐 | 一句话 | 安装 |
-|-------|------|------|--------|------|
-| [oh-story-claudecode](https://github.com/worldwonderer/oh-story-claudecode) | worldwonderer | 强推 | 13 skills + 6 agents 覆盖长篇/短篇网文全流程（扫榜/拆文/写作/去AI味/封面/导入） | `npx skills add worldwonderer/oh-story-claudecode` |
-
----
-
 ## 代码质量
 
 代码审查、测试、调试。
@@ -164,6 +153,7 @@ npx skills list
 | [Superpowers - Parallel Agents](https://github.com/obra/superpowers) | obra | 强推 | 多个子 Agent 并行执行独立任务 | `npx skills add obra/superpowers@dispatching-parallel-agents` |
 | [Superpowers - Plan Mode](https://github.com/obra/superpowers) | obra | 强推 | 先规划再执行，防止 AI 乱改代码 | `npx skills add obra/superpowers@writing-plans` |
 | [Superpowers - Git Worktrees](https://github.com/obra/superpowers) | obra | 好用 | 隔离工作区，不影响主分支 | `npx skills add obra/superpowers@using-git-worktrees` |
+| [oh-story-claudecode](https://github.com/worldwonderer/oh-story-claudecode) | worldwonderer | 强推 | 13 skills + 6 agents 覆盖长篇/短篇网文全流程（扫榜/拆文/写作/去AI味/封面/导入） | `npx skills add worldwonderer/oh-story-claudecode` |
 
 ---
 


### PR DESCRIPTION
## Summary

添加 [oh-story-claudecode](https://github.com/worldwonderer/oh-story-claudecode) — 中文网络小说写作 skill 包，同时新增「写作 / 创作」分类。

**为什么新增分类：**
现有分类（设计/UI、前端、动效/视频、营销/SEO、代码质量、工作流/方法论、无障碍）都不太适合放写作类 skill。写作/创作是一个独立的使用场景，后续如果有其他创作类 skill 也可以归类到这里。

**oh-story-claudecode 功能：**
- 13 个 Skill：扫榜（起点/番茄/晋江/知乎）、拆文分析、长篇写作、短篇写作、去AI味、封面生成、逆向导入等
- 6 个 Agent：故事架构师、角色设计师、叙事写手、一致性检查、资料研究、故事查询
- 1k+ Stars

**安装：**
```bash
npx skills add worldwonderer/oh-story-claudecode
```

推荐等级标了「强推」，作者自己提交所以不强求，maintainer 可以酌情调整。