### PR TITLE
feat: add 金融/投资分析 category with ai-investment-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ npx skills list
 - [代码质量](#代码质量)
 - [工作流 / 方法论](#工作流--方法论)
 - [无障碍](#无障碍)
+- [金融 / 投资分析](#金融--投资分析)
 - [合集 / 导航站](#合集--导航站)
 - [怎么选 Skill](#怎么选-skill)
 
@@ -161,6 +162,14 @@ npx skills list
 | Skill | 作者 | 推荐 | 一句话 | 安装 |
 |-------|------|------|--------|------|
 | [Web Accessibility](https://skills.sh/supercent-io/skills-template/web-accessibility) | Supercent | 好用 | 对比度 / 键盘导航 / 语义结构检查 | `npx skills add supercent-io/skills-template@web-accessibility` |
+
+---
+
+## 金融 / 投资分析
+
+| Skill | 作者 | 推荐 | 一句话 | 链接 |
+|-------|------|------|--------|------|
+| [**AI Investment Skills**](https://github.com/tellmefrankie/ai-investment-skills) | tellmefrankie | 强推 | 6 个投资分析 Skill：期权流扫描（捕获 XLI P/C 5.32 异常信号）、9-wave 晨间简报、止损监控、EV 计算器。真实投资组合验证，MIT 开源。 | [GitHub](https://github.com/tellmefrankie/ai-investment-skills) |
 
 ---
 


### PR DESCRIPTION
## 新增分类：金融 / 投资分析

新增 **金融 / 投资分析** 分类，收录第一个条目：

**[ai-investment-skills](https://github.com/tellmefrankie/ai-investment-skills)**

6 个 Claude Code Skills，覆盖个人投资者日常分析需求：

- **Options Flow Analyzer** — 期权流扫描，带 lottery-call 过滤器（捕获 XLI P/C 5.32 异常信号）
- **Investment Briefing Agent** — 9-wave 晨间分析：宏观 → 板块 → 技术面 → 新闻 → 批判 → 模拟
- **Price Monitor & Alert** — 止损/止盈 Telegram 实时提醒（2 秒内）
- **EV Calculator** — 概率加权牛/基/熊场景分析（免费）
- **News Sentiment Engine** — RSS 新闻情感评分（免费）
- **Multi-Agent Orchestrator** — 并行 Agent 团队 + 质量校验

**免费 Skills 可直接克隆使用。** MIT 开源，基于真实投资组合验证（6 个月以上）。

如果觉得分类名称或位置需要调整，随时告诉我。