### PR TITLE
Add Septim Agents Pack (companion to skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ npx skills list
 
 ## 怎么选 Skill
 
+- [Septim Agents Pack](https://septimlabs.com/agents) - 10 named Claude Code sub-agents (companion to skills). MIT sample at github.com/septimlabs-code/septim-agents-pack-sample.
 装太多 Skill 反而会让 Claude Code 变慢或行为混乱。建议：
 
 **第一步：装 3 个基础 Skill**


### PR DESCRIPTION
Adds the [Septim Agents Pack](https://septimlabs.com/agents) — 10 named Claude Code sub-agents covering the full exec layer for solo founders (chief of staff, CTO, brand, CMO, CFO, design, legal, customer, research, intern coordinator).

The pack ships under the Claude Code sub-agent framework: each agent is a markdown file dropped into `~/.claude/agents/`, invoked via `/agents <name>`.

One agent (Pip the intern) is open-sourced under MIT at https://github.com/septimlabs-code/septim-agents-pack-sample so anyone can see the exact named-agent + scope + refusal-conditions format before buying the full pack.

Thanks for maintaining this list.
