### PR TITLE
Add huiyu-safe-ai - AI security guard for install/download commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Awesome Claude Code Skills
 
 > Claude Code 最实用的 Skills / Agents / Plugins 精选合集，按场景分类，带安装命令，复制即用。
+  - [huiyu-safe-ai](https://github.com/huiyu9144/huiyu-safe-ai) - 轻量级AI安全卫士，用于安装/下载命令。拦截68+已知恶意软件包，验证身份，代码嗅探，零网络调用，<1秒完成。基于真实供应链攻击经验构建。
 >
 > 50+ 精选 | 按场景分类 | 带推荐等级 | 持续更新
 
@@ -255,4 +256,3 @@ npx skills add vercel-labs/skills@find-skills
 
 [MIT](LICENSE)
 
-  - [huiyu-safe-ai](https://github.com/huiyu9144/huiyu-safe-ai) - Lightweight AI security guard for install/download commands. Blocks 68+ malicious packages, verifies identity, scans code in <1s with zero overhead. Built from a real supply chain attack.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Awesome Claude Code Skills
 
 > Claude Code 最实用的 Skills / Agents / Plugins 精选合集，按场景分类，带安装命令，复制即用。
-  - [huiyu-safe-ai](https://github.com/huiyu9144/huiyu-safe-ai) - 轻量级AI安全卫士，用于安装/下载命令。拦截68+已知恶意软件包，验证身份，代码嗅探，零网络调用，<1秒完成。基于真实供应链攻击经验构建。
 >
 > 50+ 精选 | 按场景分类 | 带推荐等级 | 持续更新
 
@@ -178,6 +177,7 @@ npx skills list
 | **LobeHub Skills** | 232+ skills 的可视化浏览 | [lobehub.com/skills](https://lobehub.com/skills) |
 | **hotkeys.design** | 设计师向的 Skill 导航站 | [hotkeys.design](https://hotkeys.design) |
 | **awesomeskills.dev** | 跨平台 Agent Skill 目录 | [awesomeskills.dev](https://awesomeskills.dev) |
+| **huiyu-safe-ai** | 轻量级AI安全卫士，拦截68+已知恶意软件包，验证身份，代码嗅探，零网络调用 | [GitHub](https://github.com/huiyu9144/huiyu-safe-ai) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -254,3 +254,5 @@ npx skills add vercel-labs/skills@find-skills
 ## License
 
 [MIT](LICENSE)
+
+  - [huiyu-safe-ai](https://github.com/huiyu9144/huiyu-safe-ai) - Lightweight AI security guard for install/download commands. Blocks 68+ malicious packages, verifies identity, scans code in <1s with zero overhead. Built from a real supply chain attack.


### PR DESCRIPTION
## What does this PR add?

Adds [huiyu-safe-ai](https://github.com/huiyu9144/huiyu-safe-ai) to the list.

## What is huiyu-safe-ai?

A lightweight AI security guard for install/download commands that:
- Blocks **68+ confirmed malicious packages** (npm, PyPI, Cargo)
- Verifies package identity against **60+ trusted organizations**
- Detects **typosquatting** attacks
- Performs **code sniffing** for suspicious patterns
- **Zero network calls** — all checks happen in-memory, <1 second
- Works across **Claude Code, OpenAI Codex CLI, Trae**, and any SKILL.md compatible tool

## Why should this be included?

Created after experiencing a **real supply chain attack** (DeepSeek-TUI impersonation by APT group, May 2026). MIT licensed.
